### PR TITLE
fix: properly exports types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ node_modules
 dist
 demo/uploads
 build
+.DS_Store
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ import {
   StripeConfig,
   StripeWebhookHandler.
   StripeProxy
-} from '@payloadcms/plugin-stripe/dist/types';
+} from '@payloadcms/plugin-stripe/types';
 ```
 
 ### Development

--- a/package.json
+++ b/package.json
@@ -37,6 +37,8 @@
     "typescript": "^4.5.5"
   },
   "files": [
-    "dist"
+    "dist",
+    "types.js",
+    "types.d.ts"
   ]
 }

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,0 +1,1 @@
+export * from './dist/types';

--- a/types.js
+++ b/types.js
@@ -1,0 +1,1 @@
+module.exports = require('./dist/types');


### PR DESCRIPTION
Now types can be imported from `@payloadcms/plugin-stripe/types` instead of `@payloadcms/plugin-stripe/dist/types`.