### PR TITLE
fix: safely retrieves stripe resource before deletion #17

### DIFF
--- a/src/hooks/deleteFromStripe.ts
+++ b/src/hooks/deleteFromStripe.ts
@@ -36,8 +36,14 @@ export const deleteFromStripe: CollectionAfterDeleteHookWithArgs = async (args) 
 
     if (syncConfig) {
       try {
-        await stripe?.[syncConfig.stripeResourceType]?.del(doc.stripeID);
-        if (logs) payload.logger.info(`✅ Successfully deleted Stripe document with ID: '${doc.stripeID}'.`);
+        const found = await stripe?.[syncConfig.stripeResourceType]?.retrieve(doc.stripeID);
+
+        if (found) {
+          await stripe?.[syncConfig.stripeResourceType]?.del(doc.stripeID);
+          if (logs) payload.logger.info(`✅ Successfully deleted Stripe document with ID: '${doc.stripeID}'.`);
+        } else {
+          if (logs) payload.logger.info(`- Stripe document with ID: '${doc.stripeID}' not found, skipping...`);
+        }
       } catch (error: any) {
         throw new APIError(`Failed to delete Stripe document with ID: '${doc.stripeID}': ${error?.message || ''}`)
       }


### PR DESCRIPTION
Resolves #17 by retrieving the Stripe resource before deleting it. This way, documents that are not found in the Stripe system will not prevent the document from being deleted in Payload.