### PR TITLE
Update exception logger message

### DIFF
--- a/src/hooks/syncExistingWithStripe.ts
+++ b/src/hooks/syncExistingWithStripe.ts
@@ -63,7 +63,7 @@ export const syncExistingWithStripe: CollectionBeforeChangeHookWithArgs = async 
               )
           } catch (error: unknown) {
             const msg = error instanceof Error ? error.message : error
-            throw new APIError(`Failed to sync document with ID: '${data.id}' to Stripe: ${msg}`)
+            throw new APIError(`Failed to sync document with ID: '${data.stripeID}' to Stripe: ${msg}`)
           }
         }
       }


### PR DESCRIPTION
This resolves an issue where the logger inaccurately says `undefined` for the document id because it's pulling the wrong prop.